### PR TITLE
fix names of dependecies of Richards plugin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -439,11 +439,11 @@
 							"branch":	"master"
 						},
 						{
-							"name":		"external_AutodiffForUG4",
+							"name":		"AutodiffForUG4",
 							"branch":	"main"
 						},
 						{
-							"name":		"external_JSONForUG4",
+							"name":		"JSONForUG4",
 							"branch":	"master"
 						}
 					]


### PR DESCRIPTION
This fixes some wrong names of the dependencies of the Richards plugin.