### PR TITLE
Adding JSONToolkit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -229,6 +229,25 @@
 			"categories":		["externals"]
 		},
 		{
+			"name":				"JSONToolkit",
+			"url":				"https://github.com/UG4/JSONToolkit.git",
+			"repoType":			"git",
+			"defaultBranch":	"main",
+			"prefix":			"plugins",
+			"license":			"TBD",
+			"categories":		["plugins"],
+			"dependencies":[
+				{
+					"packages":	[
+						{
+							"name":		"JSONForUG4",
+							"branch":	"master"
+						}
+					]
+				}
+			]
+		},
+		{
 			"name":				"JupyterToolbox",
 			"url":				"https://github.com/UG4/plugin_JupyterToolbox.git",
 			"repoType":			"git",
@@ -361,7 +380,17 @@
 			"defaultBranch":	"main",
 			"prefix":			"tools",
 			"license":			"GPL 3.0",
-			"categories":		["ug4", "tools"]
+			"categories":		["ug4", "tools"],
+			"dependencies":[
+				{
+					"packages":	[
+						{
+							"name":		"JSONToolkit",
+							"branch":	"main"
+						}
+					]
+				}
+			]
 		},
 
 		{

--- a/packages.json
+++ b/packages.json
@@ -232,10 +232,10 @@
 			"name":				"JSONToolkit",
 			"url":				"https://github.com/UG4/JSONToolkit.git",
 			"repoType":			"git",
-			"defaultBranch":	"main",
+			"defaultBranch":		"main",
 			"prefix":			"plugins",
 			"license":			"TBD",
-			"categories":		["plugins"],
+			"categories":			["plugins"],
 			"dependencies":[
 				{
 					"packages":	[


### PR DESCRIPTION
Adding plugin JSONToolkit which requires JSONForUG4. JSONToolkit is also a dependency for tool ParameterEstimator.